### PR TITLE
Fix for bjoern install in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ VOLUME /music
 
 VOLUME /config
 
-RUN apt-get update && apt-get install -y gcc libev-dev python3-dev -y ffmpeg libavcodec-extra gcc-aarch64-linux-gnu && \
+RUN apt-get update && apt-get install -y gcc libev-dev python3-dev -y ffmpeg libavcodec-extra gcc-aarch64-linux-gnu libev-dev && \
 apt-get clean && \
 rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Other information:**
When building the Docker image, installing bjoern, I was given the following error:
```
bjoern/request.h:4:10: fatal error: ev.h: No such file or directory
    4 | #include <ev.h>
      |          ^~~~~~
compilation terminated.
error: command '/usr/bin/gcc' failed with exit code 1
```
Reading the [Bjoern Wiki](https://github.com/jonashaag/bjoern/wiki/Installation) I found out that the system should have `libev-dev` installed.
Installing it solves the problem.