### PR TITLE
refactor project to direct module execution

### DIFF
--- a/app/__main__.py
+++ b/app/__main__.py
@@ -1,0 +1,280 @@
+"""
+__main__ used for executing module directly e.g. `pyhton -m swingmusic`
+"""
+
+import os
+import logging
+import mimetypes
+import setproctitle
+from pathlib import Path
+
+from flask_jwt_extended import (
+    create_access_token,
+    get_jwt,
+    get_jwt_identity,
+    set_access_cookies,
+    verify_jwt_in_request,
+)
+from datetime import datetime, timezone
+from flask import Response, request
+
+from app import settings
+from app.api import create_api
+from app.crons import start_cron_jobs
+from app.utils.threading import background
+from app.setup import load_into_mem, run_setup
+from app.plugins.register import register_plugins
+from app.start_info_logger import log_startup_info
+from app.utils.filesystem import get_home_res_path
+from app.utils.paths import getClientFilesExtensions
+import os
+import sys
+import click
+import pathlib
+import multiprocessing
+from app.arg_handler import handle_build, handle_password_reset
+from app.utils.filesystem import get_home_res_path
+from app.utils.xdg_utils import get_xdg_config_dir
+from manage import run_app
+
+
+
+def version(*args, **kwargs):
+    if not args[2]:
+        return
+
+    path = get_home_res_path("version.txt")
+    if not path:
+        click.echo("Version file not found.")
+        sys.exit(1)
+
+    with open(path, "r") as f:
+        version = f.read()
+
+    click.echo(version)
+    sys.exit(0)
+
+
+def run_app(host: str, port: int, config: Path):
+    settings.Paths.set_config_dir(config)
+
+    # Load mimetypes for the web client's static files
+    # Loading mimetypes should happen automatically but
+    # sometimes the mimetypes are not loaded correctly
+    # eg. when the Registry is messed up on Windows.
+
+    # See the following issues:
+    # https://github.com/swingmx/swingmusic/issues/137
+
+    mimetypes.add_type("text/css", ".css")
+    mimetypes.add_type("text/javascript", ".js")
+    mimetypes.add_type("text/plain", ".txt")
+    mimetypes.add_type("text/html", ".html")
+    mimetypes.add_type("image/webp", ".webp")
+    mimetypes.add_type("image/svg+xml", ".svg")
+    mimetypes.add_type("image/png", ".png")
+    mimetypes.add_type("image/vnd.microsoft.icon", ".ico")
+    mimetypes.add_type("image/gif", ".gif")
+    mimetypes.add_type("font/woff", ".woff")
+    mimetypes.add_type("application/manifest+json", ".webmanifest")
+
+    # logging.disable(logging.CRITICAL)
+    # werkzeug = logging.getLogger("werkzeug")
+    # werkzeug.setLevel(logging.ERROR)
+
+    waitress_logger = logging.getLogger("waitress")
+    waitress_logger.setLevel(logging.ERROR)
+
+    log_startup_info(host, port)
+
+    @background
+    def run_swingmusic():
+        register_plugins()
+
+        setproctitle.setproctitle(f"swingmusic {host}:{port}")
+        start_cron_jobs()
+
+    # Setup function calls
+    settings.Info.load()
+    run_setup()
+
+    # Create the Flask app
+    app = create_api()
+    app.static_folder = get_home_res_path("client")
+
+    # INFO: Routes that don't need authentication
+    whitelisted_routes = {
+        "/auth/login",
+        "/auth/users",
+        "/auth/pair",
+        "/auth/logout",
+        "/auth/refresh",
+        "/docs",
+    }
+    blacklist_extensions = {".webp", ".jpg"}.union(getClientFilesExtensions())
+
+    def skipAuthAction():
+        """
+        Skips the JWT verification for the current request.
+        """
+        if request.path == "/" or any(
+            request.path.endswith(ext) for ext in blacklist_extensions
+        ):
+            return True
+
+        # if request path starts with any of the blacklisted routes, don't verify jwt
+        if any(request.path.startswith(route) for route in whitelisted_routes):
+            return True
+
+        return False
+
+    @app.before_request
+    def verify_auth():
+        """
+        Verifies the JWT token before each request.
+        """
+        if skipAuthAction():
+            return
+
+        verify_jwt_in_request()
+
+    @app.after_request
+    def refresh_expiring_jwt(response: Response):
+        """
+        Refreshes the cookies JWT token after each request.
+        """
+
+        # INFO: If the request has an Authorization header, don't refresh the jwt
+        # Request is probably from the mobile client or a third party
+        if skipAuthAction() or request.headers.get("Authorization"):
+            return response
+
+        try:
+            exp_timestamp = get_jwt()["exp"]
+            now = datetime.now(timezone.utc)
+            target_timestamp = datetime.timestamp(now) + 60 * 60 * 24 * 7  # 7 days
+
+            if target_timestamp > exp_timestamp:
+                access_token = create_access_token(identity=get_jwt_identity())
+                set_access_cookies(response, access_token)
+
+            return response
+        except (RuntimeError, KeyError):
+            return response
+
+    @app.route("/<path:path>")
+    def serve_client_files(path: str):
+        """
+        Serves the static files in the client folder.
+        """
+        js_or_css = path.endswith(".js") or path.endswith(".css")
+        if not js_or_css:
+            return app.send_static_file(path)
+
+        gzipped_path = path + ".gz"
+        user_agent = request.headers.get("User-Agent")
+
+        # INFO: Safari doesn't support gzip encoding
+        # See issue: https://github.com/swingmx/swingmusic/issues/155
+        is_safari = (
+            user_agent
+            and user_agent.find("Safari") >= 0
+            and user_agent.find("Chrome") < 0
+        )
+
+        if is_safari:
+            return app.send_static_file(path)
+
+        accepts_gzip = request.headers.get("Accept-Encoding", "").find("gzip") >= 0
+
+        if accepts_gzip:
+            if os.path.exists(os.path.join(app.static_folder or "", gzipped_path)):
+                response = app.make_response(app.send_static_file(gzipped_path))
+                response.headers["Content-Encoding"] = "gzip"
+                return response
+
+        return app.send_static_file(path)
+
+    @app.route("/")
+    def serve_client():
+        """
+        Serves the index.html file at `client/index.html`.
+        """
+        return app.send_static_file("index.html")
+
+    load_into_mem()
+    run_swingmusic()
+    # TrackStore.export()
+    # ArtistStore.export()
+
+    try:
+        import bjoern
+
+        bjoern.run(app, host, port)
+    except ImportError:
+        import waitress
+
+        waitress.serve(
+            app,
+            host=host,
+            port=port,
+            threads=100,
+            ipv6=True,
+            ipv4=True,
+        )
+
+
+@click.command(options_metavar="<options>", context_settings={"show_default": True})
+@click.option(
+    "--build",
+    default=False,
+    help="Build the project.",
+    is_eager=True,
+    callback=handle_build,
+    is_flag=True,
+)
+
+@click.option("--host", default="0.0.0.0", help="Host to run the app on.")
+@click.option("--port", default=1970, help="HTTP port to run the app on.")
+@click.option(
+    "--config",
+    default=lambda: get_xdg_config_dir(),
+    show_default="XDG_CONFIG_HOME",
+    help="Path to the config file.",
+    type=click.Path(
+        exists=True,
+        file_okay=False,
+        dir_okay=True,
+        writable=True,
+        resolve_path=True,
+        allow_dash=False,
+        path_type=pathlib.Path,
+    ),
+)
+@click.option(
+    "--password-reset",
+    is_flag=True,
+    help="Reset the password.",
+    is_eager=True,
+    callback=handle_password_reset,
+)
+@click.option(
+    "--version",
+    is_flag=True,
+    default=False,
+    callback=version,
+    help="Show the version and exit",
+    is_eager=True,
+)
+
+def run(*args, **kwargs):
+    # INFO: Set the config dir as an environment variable
+    os.environ["SWINGMUSIC_XDG_CONFIG_DIR"] = str(
+        pathlib.Path(kwargs["config"]).resolve()
+    )
+    run_app(kwargs["host"], kwargs["port"], kwargs["config"])
+
+
+if __name__ == "__main__":
+    multiprocessing.freeze_support()
+    run()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,37 +6,56 @@ readme = "README.md"
 requires-python = ">=3.11, <3.12"
 
 dependencies = [
-    "pillow>=11.1.0",
+    "colorgram.py>=1.2.0",
     "Flask>=3.1.0",
     "Flask-Cors>=3.0.10",
+    "flask-openapi3==3.0.2",
+    "flask-compress>=1.13",
+    "flask-jwt-extended>=4.6.0",
+    "ffmpeg-python>=0.2.0",
+    "locust>=2.20.1",
+    "memory-profiler>=0.61.0",
+    "pillow>=11.1.0",
+    "psutil>=5.9.4",
+    "pillow>=11.1.0",
+    "pendulum>=3.0.0",
+    "rapidfuzz==3.11.0",
     "requests>=2.27.1",
-    "colorgram.py>=1.2.0",
+    "show-in-file-manager>=1.1.4",
+    "setproctitle>=1.3.2",
+    "schedule>=1.2.2",
+    "sqlalchemy>=2.0.31",
+    "sortedcontainers>=2.4.0",
+    "tabulate>=0.9.0",
     "tqdm>=4.65.0",
     "tinytag>=2.0.0",
     "Unidecode>=1.3.6",
-    "psutil>=5.9.4",
-    "show-in-file-manager>=1.1.4",
-    "flask-compress>=1.13",
-    "tabulate>=0.9.0",
-    "setproctitle>=1.3.2",
-    "locust>=2.20.1",
     "watchdog>=4.0.0",
-    "flask-jwt-extended>=4.6.0",
-    "sqlalchemy>=2.0.31",
-    "memory-profiler>=0.61.0",
-    "sortedcontainers>=2.4.0",
     "xxhash>=3.4.1",
-    "ffmpeg-python>=0.2.0",
-    "schedule>=1.2.2",
-    "pillow>=11.1.0",
-    "flask-openapi3==3.0.2",
-    "rapidfuzz==3.11.0",
-    "waitress>=3.0.2",
-    "pendulum>=3.0.0",
-    "bjoern>=3.2.2",
+    "waitress>=3.0.2; sys_platform == 'win32'",
+    "bjoern >=3.2.2; sys_platform != 'win32'"
 ]
 
 [dependency-groups]
 dev = [
     "pyinstaller==6.12.0",
 ]
+
+
+[project.urls]
+homepage = "https://swingmx.com/"
+repository = "https://github.com/swingmx/swingmusic"
+documentation = "https://swingmx.com/guide/introduction.html"
+"Bug Tracker" = "https://github.com/swingmx/swingmusic/issues"
+
+
+[tool.poetry]
+packages = [
+    { include = "app" , to = "swingmusic"}
+]
+
+[tool.setuptools.package-dir]
+swingmusic = "app"
+
+[tool.poetry.scripts]
+swingmusic = "swingmusic.__main__:run"


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/swing-opensource/swingmusic/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

`__main__.py`: 
* combination of main and manage

`pyproject.toml`:
* sort dependencies by name
* add support for poetry and setuptools install
* add entrypoints for direct execution without `python -m swingmusic`
* set system specific dependencies

Project can be installed by pip and poetry.

now you can either use `python -m swingmusic`,`swingmusic` directly or `poetry run swingmusic` to launch the project.
PyInstaller is not configured for this change, but the current way to build and start still work.

`Questions`:
* This project uses the flat architecture. I am not sure if it is the default structure for poetry projects.
* Is there any documentation how this project is organized?
* Is this change wanted. If yes then i would change the pyinstaller to build with the new configuration.
* does poetry support `editable` installs of projects or how are you testing changes in code?