### PR TITLE
update `pyproject.toml` and project metafiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,3 @@
-# local env files
-.env.local
-.env.*.local
-venv
-
 # Editor directories and files
 .idea
 .vscode
@@ -22,10 +17,8 @@ encoderx.py
 dist
 build
 client
-.gitignore
 
 logs.txt
-*.spec
 
 # TODO.md
 testdata.py
@@ -35,3 +28,190 @@ nohup.out
 
 
 .DS_Store
+
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+docs/source/_build
+docs/source/apidocs
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# UV
+#   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#uv.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/latest/usage/project/#working-with-version-control
+.pdm.toml
+.pdm-python
+.pdm-build/
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env.local
+.env.*.local
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+# Ruff stuff:
+.ruff_cache/
+
+# PyPI configuration file
+.pypirc
+
+# Cursor
+#  Cursor is an AI-powered code editor.`.cursorignore` specifies files/directories to
+#  exclude from AI features like autocomplete and code analysis. Recommended for sensitive data
+#  refer to https://docs.cursor.com/context/ignore-files
+.cursorignore
+.cursorindexingignore

--- a/README.md
+++ b/README.md
@@ -149,16 +149,6 @@ git clone git@github.com:swingmx/swingmusic.git
 uv sync
 ```
 
-```sh
-# 3. Install wsgi server
-
-# If you are on Windows, install waitress:
-uv pip install waitress
-
-# If you are on Unix, install bjoern:
-uv pip install bjoern
-```
-
 > [!TIP]
 > The `libev` package is needed on Linux and MacOS. You can install it on other system as shown:
 > 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,13 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
 [project]
 name = "swingmusic"
 version = "2.0.6"
 description = "Swing Music"
 readme = "README.md"
-requires-python = ">=3.11, =<3.13"
-
+requires-python = ">=3.11, <=3.12"
 
 dependencies = [
     "pillow>=11.1.0",
@@ -38,6 +41,12 @@ dependencies = [
     "bjoern >=3.2.2; sys_platform != 'win32'"
 ]
 
+[tool.uv]
+dependency-metadata = [
+    { name = "waitress", version = "3.0.2", requires-dist = [], requires-python = ">=3.11" },
+    { name = "bjoern", version="3.2.2", requires-dist = [], requires-python = ">=3.11"}
+]
+
 [project.scripts]
 swingmusic = "swingmusic.__main__:main"
 
@@ -64,7 +73,7 @@ docs = [
 ]
 
 [tool.setuptools]
-package-dir = {"" = "swingmusic"}
+package-dir = {"swingmusic" = "swingmusic"}
 
 [tool.setuptools.package-data]
 swingmusic = ["client/*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,8 @@ name = "swingmusic"
 version = "2.0.6"
 description = "Swing Music"
 readme = "README.md"
-requires-python = ">=3.11, <3.12"
+requires-python = ">=3.11, =<3.13"
+
 
 dependencies = [
     "pillow>=11.1.0",
@@ -33,9 +34,37 @@ dependencies = [
     "rapidfuzz==3.11.0",
     "pendulum>=3.0.0",
     "pystray>=0.19.5",
+    "waitress>=3.0.2; sys_platform == 'win32'",
+    "bjoern >=3.2.2; sys_platform != 'win32'"
 ]
 
-[dependency-groups]
+[project.scripts]
+swingmusic = "swingmusic.__main__:main"
+
+
+[project.urls]
+Homepage = "https://swingmx.com/"
+Repository = "https://github.com/swingmx/swingmusic"
+Documentation = "https://swingmx.com/guide/introduction.html"
+Issues = "https://github.com/swingmx/swingmusic/issues"
+
+
+[project.optional-dependencies]
 dev = [
     "pyinstaller==6.12.0",
 ]
+
+docs = [
+    "sphinx",
+    "furo",
+    "sphinx_design",
+    "myst_parser",
+    "sphinx",
+    "sphinx-autodoc2",
+]
+
+[tool.setuptools]
+package-dir = {"" = "swingmusic"}
+
+[tool.setuptools.package-data]
+swingmusic = ["client/*"]

--- a/swingmusic/__main__.py
+++ b/swingmusic/__main__.py
@@ -108,7 +108,10 @@ def run(*args, **kwargs):
     start_swingmusic(kwargs["host"], kwargs["port"])
 
 
-if __name__ == "__main__":
+def main():
     multiprocessing.freeze_support()
     multiprocessing.set_start_method("spawn")
     run()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
`pyproject.tom`:
* set explicit build system
* Supported python version is capped to 3.12 because of audioop being deprecated in 3.13
* add waitress and bjoern as platform dependent deps
* add entry-point
* add project urls
* set explicit flat layout structure
* add package data
* add optional dep `docs`
* add static dependency metadata for platform dependent dependencies
* explicit set namespace of swingmusic

`__main__.py`:
* add main function
* call main function from entrypoint and with direct execution

`.gitignore`:
* extend gitignore by recommended values

`README.md`:
* remove platform-dependent wsgi server. now being managed in pyproject.toml


**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [x] Other, please describe: