### PR TITLE
fix lyrics is a list bug

### DIFF
--- a/swingmusic/lib/lyrics.py
+++ b/swingmusic/lib/lyrics.py
@@ -186,13 +186,16 @@ def get_lyrics_from_tags(trackhash: str, just_check: bool = False):
     if just_check:
         return lyrics is not None
 
-    if lyrics:
+    if isinstance(lyrics, list):
+        lyrics = lyrics[0]
+
+    if isinstance(lyrics, str):
         lyrics = lyrics.replace("engdesc", "")
     else:
         return None, False, ""
 
     lines = lyrics.split("\n")
-    synced = test_is_synced(lines[:15])
+    synced = test_is_synced(lines[5:15])
 
     if synced:
         return format_synced_lyrics(lines), synced, copyright


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

fixing bug #271 
`lyrics`-key in `extras` can be a list.
Database also stores `lyrics` in a list.
just add a check to convert list to `str`

Metadata inside the lyrics can interfere, when testing if lyrics are synced.
Just added a temporary fix to only start checking from the fifth line.