### PR TITLE
add EnvStore & differentiate between container and internal vars

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,7 @@
+---
+name: Bug report
+about: You found a bug and what to report it.
+title: ''
+labels: ''
+assignees: ''
+---

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -4,6 +4,15 @@ title: "[Bug]: "
 labels: [""]
 projects: [""]
 body:
+  - type: input
+    id: os-version
+    attributes:
+      label: What OS are you using?
+      description: On what version and OS did the error occur?
+      placeholder: Windows 11
+    validations:
+      required: true
+
   - type: dropdown
     id: dist
     attributes:
@@ -21,14 +30,12 @@ body:
       required: true
 
   - type: input
-    id: os-version
+    id: command
     attributes:
-      label: What OS are you using?
-      description: On what version and OS did the error occur?
-      placeholder: Windows 11
+      label: Used command
+      description: What command if any did you use to launch swingmusic
     validations:
-      required: true
-
+      required: false
 
   - type: input
     id: version

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,67 @@
+name: Bug report
+description: File a bug report.
+title: "[Bug]: "
+labels: [""]
+projects: [""]
+body:
+  - type: dropdown
+    id: dist
+    attributes:
+      label: What package do you use?
+      description: What package did you use to install swingmusic?
+      multiple: false
+      options:
+        - "Pyinstaller (win: .exe, mac/linux: no extension)"
+        - AppImage
+        - Wheel / pip
+        - Docker
+        - Source
+      default: 0
+    validations:
+      required: true
+
+  - type: input
+    id: os-version
+    attributes:
+      label: What OS are you using?
+      description: On what version and OS did the error occur?
+      placeholder: Windows 11
+    validations:
+      required: true
+
+
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: What version of swingmusic did you run?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: browsers
+    attributes:
+      label: Where did the bug happen?
+      multiple: true
+      options:
+        - Firefox
+        - Chrome
+        - Safari
+        - Microsoft Edge
+        - Android
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What ?
+      placeholder: Tell us what you see!
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      render: shell


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [x] Other, please describe:

## EnvStore
Add `EnvStore` for multiprocessing save variables.
The `EnvStore` is used to differentiate between container/docker environment vars and internal used environment vars.

Currently only `Paths` is migrated to `EnvStore`.

## centralize all read only globals
To mitigate the likelihood of circular imports, all read only globals are moved into the `shared.py` file.
This change is to reflect this behavior on a files level.

## update pyproject.toml
correct the pyproject optional dependencies.
Thanks @cwilvx for notifying about the wrong tag.
Also add the zip file to project data so it is packed correctly.

## reformat main
Reformat main to display the difference between user provided vars and env/default.

There was no distinct difference between user provided vars and env/default ones.
This caused complicated code as there was only on function managing everything.
Additionally internal env vars where mixed with external like `Paths`. 
This was mostly fixed by introducing `EnvStore`.

The main function now checks user paths and exists if there are unsupported.
This also reflects the default `check and default` path process.