### PR TITLE
fix #459: use UTC for release year display

### DIFF
--- a/src/swingmusic/api/artist.py
+++ b/src/swingmusic/api/artist.py
@@ -3,9 +3,8 @@ Contains all the artist(s) routes.
 """
 
 import math
-from pprint import pprint
 import random
-from datetime import datetime
+from datetime import datetime, timezone
 from itertools import groupby
 from typing import Any
 
@@ -69,7 +68,7 @@ def get_artist(path: ArtistHashSchema, query: GetArtistQuery):
         limit = tcount
 
     try:
-        year = datetime.fromtimestamp(artist.date).year
+        year = datetime.fromtimestamp(artist.date, tz=timezone.utc).year
     except ValueError:
         year = 0
 

--- a/src/swingmusic/api/getall/__init__.py
+++ b/src/swingmusic/api/getall/__init__.py
@@ -3,7 +3,7 @@ from natsort import natsorted
 from pydantic import BaseModel, Field
 from flask_openapi3 import APIBlueprint
 
-from datetime import datetime
+from datetime import datetime, timezone
 from swingmusic.config import UserConfig
 from swingmusic.store.albums import AlbumStore
 from swingmusic.store.artists import ArtistStore
@@ -138,7 +138,9 @@ def get_all_items(path: GetAllItemsPath, query: GetAllItemsQuery):
         item_dict = serialize_album(item) if is_albums else serialize_artist(item)
 
         if sort_is_date:
-            item_dict["help_text"] = datetime.fromtimestamp(item.date).year
+            item_dict["help_text"] = datetime.fromtimestamp(
+                item.date, tz=timezone.utc
+            ).year
 
         if sort_is_create_date:
             date = create_new_date(datetime.fromtimestamp(item.created_date))


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/swing-opensource/swingmusic/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

This fixes a timezone-dependent release year display issue.

Root cause:
- Release year was derived using local timezone conversion from timestamps.
- In negative UTC offsets (e.g., America/New_York), 2026-01-01 00:00:00 UTC could display as 2025.

Changes:
- Use UTC conversion when deriving release year for display in artist and get all album date paths.
- Keep other timestamp displays (created_date, last played) unchanged.

Validation:
- Reproduced timezone difference with a small script.
- Ran Ruff on changed files:
  uv run ruff check src/swingmusic/api/artist.py src/swingmusic/api/getall/__init__.py
- Result: all checks passed.

Closes #459