### PR TITLE
feat: search item by it's hash

### DIFF
--- a/src/swingmusic/api/search.py
+++ b/src/swingmusic/api/search.py
@@ -20,6 +20,7 @@ tag = Tag(name="Search", description="Search for tracks, albums and artists")
 api = APIBlueprint("search", __name__, url_prefix="/search", abp_tags=[tag])
 
 SEARCH_COUNT = 30
+HASH_QUERY_LENGTH = 16
 """
 The max amount of items to return per request
 """
@@ -54,11 +55,53 @@ class Search:
         self.tracks: list[models.Track] = []
         self.query = unidecode(query)
 
+    def _is_hash_query(self) -> bool:
+        return len(self.query) == HASH_QUERY_LENGTH
+
+    def _search_tracks_by_hash(self):
+        if not self._is_hash_query():
+            return None
+
+        group = TrackStore.trackhashmap.get(self.query)
+        if group:
+            return group.tracks
+
+        return []
+
+    def _search_artist_by_hash(self):
+        if not self._is_hash_query():
+            return None
+
+        from swingmusic.store.artists import ArtistStore
+
+        artist = ArtistStore.get_artist_by_hash(self.query)
+        if artist:
+            return serialize_for_cards([artist])
+
+        return []
+
+    def _search_album_by_hash(self):
+        if not self._is_hash_query():
+            return None
+
+        from swingmusic.serializers.album import serialize_for_card_many
+        from swingmusic.store.albums import AlbumStore
+
+        album = AlbumStore.get_album_by_hash(self.query)
+        if album:
+            return serialize_for_card_many([album])
+
+        return []
+
     def search_tracks(self):
         """
         Calls :class:`SearchTracks` which returns the tracks that fuzzily match
         the search terms. Then adds them to the `SearchResults` store.
         """
+        tracks = self._search_tracks_by_hash()
+        if tracks is not None:
+            return tracks
+
         self.tracks = TrackStore.get_flat_list()
         return searchlib.TopResults().search(self.query, tracks_only=True)
 
@@ -66,13 +109,20 @@ class Search:
         """Calls :class:`SearchArtists` which returns the artists that fuzzily match
         the search term. Then adds them to the `SearchResults` store.
         """
-        artists = searchlib.SearchArtists(self.query)()
-        return serialize_for_cards(artists)
+        artists = self._search_artist_by_hash()
+        if artists is not None:
+            return artists
+
+        return serialize_for_cards(searchlib.SearchArtists(self.query)())
 
     def search_albums(self):
         """Calls :class:`SearchAlbums` which returns the albums that fuzzily match
         the search term. Then adds them to the `SearchResults` store.
         """
+        albums = self._search_album_by_hash()
+        if albums is not None:
+            return albums
+
         return searchlib.TopResults().search(self.query, albums_only=True)
 
     def get_top_results(


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/swing-opensource/swingmusic/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

Initially, I needed an endpoint to get information about a single track by its hash, so I implemented an addition to the search functionality. Now, I can retrieve a song by hash not only through the API, but also via the web interface.

If you type the exact hash of a song, artist, or album, you will get that specific item; otherwise, the search behaves as usual.

P.S. I really love Swing Music for its simplicity and elegant interface, but without this feature, I’d have to maintain my own fork, which seems harder to manage in the long run. A merge would be highly appreciated.